### PR TITLE
xmllint now exists in libxml2-utils

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ all:
 
 checkdeps:
 	@if ! which tidy &>/dev/null ; then echo "Tool tidy not found, try sudo apt-get install tidy" 1>&2 ; exit 1 ; fi
-	@if ! which xmllint &>/dev/null ; then echo "Tool xmllint not found, try sudo apt-get install libxml2-bin" 1>&2 ; exit 1 ; fi
+	@if ! which xmllint &>/dev/null ; then echo "Tool xmllint not found, try sudo apt-get install libxml2-utils" 1>&2 ; exit 1 ; fi
 	@if ! [ -d /usr/share/tt-rss/www/plugins/ ]; then echo "It doesn't look like tt-rss is installed" 1>&2 ; exit 1 ; fi
 
 install: checkdeps


### PR DESCRIPTION
xmllint in Debian stable and Ubuntu 12.04+ is in the libxml2-utils package
