### PR TITLE
Fix "ReferenceError: Ajax is not defined" when saving prefs

### DIFF
--- a/init.php
+++ b/init.php
@@ -56,14 +56,10 @@ class Ff_XmlLint extends Plugin {
 		print "<script type=\"dojo/method\" event=\"onSubmit\" args=\"evt\">
 			evt.preventDefault();
 			if (this.validate()) {
-				console.log(dojo.objectToQuery(this.getValues()));
-				new Ajax.Request('backend.php', {
-					parameters: dojo.objectToQuery(this.getValues()),
-					onComplete: function(transport) {
-						notify_info(transport.responseText);
-					}
+				console.log(this.getValues());
+				xhr.post('backend.php', this.getValues(), (reply) => {
+					Notify.info(reply);
 				});
-				//this.reset();
 			}
 			</script>";
 


### PR DESCRIPTION
I was running into this error when trying to save plugin preferences. I don't think the `Ajax` object is around in recent versions of ttrss. I don't really know what I'm doing with PHP or JavaScript, but I copied what https://github.com/HenryQW/mercury_fulltext/blob/master/init.php does and it seems to work now.